### PR TITLE
Add the ability for humans to heal their team members

### DIFF
--- a/src/cgame/cg_event.c
+++ b/src/cgame/cg_event.c
@@ -1228,6 +1228,31 @@ void CG_EntityEvent( centity_t *cent, vec3_t position )
       break;
 
     case EV_MEDKIT_USED:
+      // the parameter is the healer's entity number
+      {
+        const int   healerNum = es->eventParm;
+        const char  *configstring;
+        const char  *name;
+
+        if( healerNum != clientNum )
+        {
+          if( healerNum == cg.clientNum )
+          {
+            configstring = CG_ConfigString( clientNum + CS_PLAYERS );
+            // isolate the player's name
+            name = Info_ValueForKey( configstring, "n" );
+
+            CG_Printf( S_COLOR_CYAN "You bandaged " S_COLOR_WHITE "%s" S_COLOR_CYAN "'s wounds.\n", name );
+          } else if( clientNum == cg.clientNum )
+          {
+            configstring = CG_ConfigString( healerNum + CS_PLAYERS );
+            // isolate the player's name
+            name = Info_ValueForKey( configstring, "n" );
+
+            CG_Printf( S_COLOR_WHITE "%s" S_COLOR_CYAN " bandaged your wounds.\n", name );
+          }
+        }
+      }
       trap_S_StartSound( NULL, es->number, CHAN_AUTO, cgs.media.medkitUseSound );
       break;
 

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1042,6 +1042,7 @@ void      G_UnregisterCommands( void );
 void FireWeapon( gentity_t *ent );
 void FireWeapon2( gentity_t *ent );
 void FireWeapon3( gentity_t *ent );
+gentity_t *G_MedkitTarget( gentity_t *ent );
 
 //
 // g_main.c
@@ -1179,6 +1180,8 @@ extern  vmCvar_t  g_suddenDeathVoteDelay;
 extern  vmCvar_t  g_readyPercent;
 extern  vmCvar_t  g_armageddonVotePercent;
 extern  vmCvar_t  g_armageddonPercent;
+extern  vmCvar_t  g_humanMedkitRange;
+extern  vmCvar_t  g_humanMedkitWidth;
 extern  vmCvar_t  g_teamForceBalance;
 extern  vmCvar_t  g_smoothClients;
 extern  vmCvar_t  pmove_fixed;

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -86,6 +86,8 @@ vmCvar_t  g_suddenDeathVotePercent;
 vmCvar_t  g_suddenDeathVoteDelay;
 vmCvar_t  g_armageddonVotePercent;
 vmCvar_t  g_armageddonPercent; 
+vmCvar_t  g_humanMedkitRange;
+vmCvar_t  g_humanMedkitWidth;
 vmCvar_t  g_readyPercent;
 vmCvar_t  g_teamForceBalance;
 vmCvar_t  g_smoothClients;
@@ -217,6 +219,8 @@ static cvarTable_t   gameCvarTable[ ] =
   { &g_maxclients, "sv_maxclients", "8", CVAR_SERVERINFO | CVAR_LATCH | CVAR_ARCHIVE, 0, qfalse  },
   { &g_maxGameClients, "g_maxGameClients", "0", CVAR_SERVERINFO | CVAR_ARCHIVE, 0, qfalse  },
   { &g_timelimit, "timelimit", "0", CVAR_SERVERINFO | CVAR_ARCHIVE | CVAR_NORESTART, 0, qtrue },
+  { &g_humanMedkitRange, "g_humanMedkitRange", "200", CVAR_ARCHIVE, 0, qfalse },
+  { &g_humanMedkitWidth, "g_humanMedkitWidth", "20", CVAR_ARCHIVE, 0, qfalse },
   { &g_suddenDeathTime, "g_suddenDeathTime", "40", CVAR_SERVERINFO | CVAR_ARCHIVE | CVAR_NORESTART, 0, qtrue },
   { &g_armageddonTimeStep, "g_armageddonTimeStep", "5", CVAR_SERVERINFO | CVAR_ARCHIVE | CVAR_NORESTART, 0, qtrue },
   { &g_armageddonInitialTimeStep, "g_armageddonInitialTimeStep", "10", CVAR_SERVERINFO | CVAR_ARCHIVE | CVAR_NORESTART, 0, qtrue },

--- a/src/game/g_weapon.c
+++ b/src/game/g_weapon.c
@@ -1454,6 +1454,37 @@ void G_ClearPlayerZapEffects( gentity_t *player )
   }
 }
 
+
+/*
+===============
+G_MedkitTarget
+
+Look for a possible healing target (a client) in the front.
+===============
+*/
+gentity_t *G_MedkitTarget( gentity_t *ent )
+{
+  trace_t   tr;
+  gentity_t *targetEnt = NULL;
+
+  if( g_humanMedkitRange.value <= 0 ||
+      g_humanMedkitWidth.value <= 0 )
+    return NULL;
+
+  // Calculate muzzle point
+  AngleVectors( ent->client->ps.viewangles, forward, right, up );
+  CalcMuzzlePoint( ent, forward, right, up, muzzle );
+
+  G_WideTrace( &tr, ent, g_humanMedkitRange.value,
+      g_humanMedkitWidth.value, g_humanMedkitWidth.value, &targetEnt );
+
+  if( ( targetEnt != NULL ) &&
+      ( targetEnt->client != NULL ) )
+    return targetEnt;
+  else
+    return NULL;
+}
+
 /*
 ===============
 areaZapFire


### PR DESCRIPTION
The medkit handling is moved to a new function G_UseMedkit.
If there is a human within a given range that is either more wounded
than the player, or poisoned, the medkit is applied to him
(see G_NeedsMedkit).

The range and the breadth of the action is configurable by cvars.

The original patch was used on a server, but this port wasn't tested
(only that it compiles).
