### PR TITLE
Rets vs acids

### DIFF
--- a/src/game/g_buildable.c
+++ b/src/game/g_buildable.c
@@ -2891,9 +2891,20 @@ qboolean HMGTurret_CheckTarget( gentity_t *self, gentity_t *target,
   trace_t   tr;
   vec3_t    dir, end;
 
-  if( !target || target->health <= 0 || !target->client ||
-      target->client->pers.teamSelection != TEAM_ALIENS )
-    return qfalse;
+  if( !target || target->health <= 0 )
+     return qfalse;
+
+  if( target->client )
+  {
+    if( target->client->pers.teamSelection != TEAM_ALIENS )
+      return qfalse;
+  }
+  else
+  {
+    if( !( target->s.eType == ET_BUILDABLE &&
+           BG_Buildable( target->s.modelindex )->team == TEAM_ALIENS ) )
+      return qfalse;
+  }
 
   if( target->flags & FL_NOTARGET )
     return qfalse;

--- a/src/game/g_buildable.c
+++ b/src/game/g_buildable.c
@@ -1505,7 +1505,9 @@ void AAcidTube_Think( gentity_t *self )
       if (enemy->client && enemy->client->notrackEndTime >= level.time)
       	continue;
 
-      if( enemy->client && enemy->client->ps.stats[ STAT_TEAM ] == TEAM_HUMANS )
+      if( ( enemy->client && enemy->client->ps.stats[ STAT_TEAM ] == TEAM_HUMANS ) ||
+          ( enemy->s.eType == ET_BUILDABLE &&
+            BG_Buildable( enemy->s.modelindex )->team == TEAM_HUMANS ) )
       {
         // start the attack animation
         if( level.time >= self->timestamp + ACIDTUBE_REPEAT_ANIM )

--- a/src/game/g_combat.c
+++ b/src/game/g_combat.c
@@ -1571,8 +1571,10 @@ qboolean G_SelectiveRadiusDamage( vec3_t origin, gentity_t *attacker, float dama
 
     points = damage * ( 1.0 - dist / radius );
 
-    if( CanDamage( ent, origin ) && ent->client &&
-        ent->client->ps.stats[ STAT_TEAM ] != team )
+    if( CanDamage( ent, origin ) &&
+        ( ( ent->client && ent->client->ps.stats[ STAT_TEAM ] != team ) ||
+          ( ent->s.eType == ET_BUILDABLE &&
+            BG_Buildable( ent->s.modelindex )->team != team ) ) )
     {
       VectorSubtract( ent->r.currentOrigin, origin, dir );
       // push the center of mass higher than the origin so players


### PR DESCRIPTION
Allow turrets target alien structures, as well as acid tubes target human structures.

This way, a sneaky builder can cause a lot of damage to the enemy base.